### PR TITLE
Guild Configs and Multip PR and Issue Scans

### DIFF
--- a/src/main/java/org/mangorage/mangobot/MangoBotPlugin.java
+++ b/src/main/java/org/mangorage/mangobot/MangoBotPlugin.java
@@ -29,6 +29,7 @@ import static org.mangorage.mangobot.core.BotPermissions.PLAYING;
 import static org.mangorage.mangobot.core.BotPermissions.PREFIX_ADMIN;
 import static org.mangorage.mangobot.core.BotPermissions.TRICK_ADMIN;
 
+import java.nio.file.Path;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.Scanner;
@@ -36,6 +37,7 @@ import java.util.Scanner;
 import org.mangorage.basicutils.config.Config;
 import org.mangorage.basicutils.config.ConfigSetting;
 import org.mangorage.basicutils.config.ISetting;
+import org.mangorage.mangobot.config.GuildConfig;
 import org.mangorage.mangobot.core.BotEventListener;
 import org.mangorage.mangobot.core.BotPermissions;
 import org.mangorage.mangobot.core.Listeners;
@@ -125,8 +127,7 @@ public class MangoBotPlugin extends CorePlugin {
     );
 
     // Where we create our "config"
-    public final static Config CONFIG = new Config("plugins/%s/".formatted(MangoBotPlugin.ID), ".env");
-
+    public final static Config CONFIG = new Config(Path.of("plugins/%s/.env".formatted(MangoBotPlugin.ID)));
 
     // Where we create Settings for said Config
     public static final ISetting<String> MAPPINGS_VERSION = ConfigSetting.create(CONFIG, "MAPPINGS_VERSION", "empty");
@@ -237,14 +238,15 @@ public class MangoBotPlugin extends CorePlugin {
         cmdRegistry.addBasicCommand(new GetEmbedsCommand());
 
 
+        cmdRegistry.addBasicCommand(new PRScanCommand(this));
+        cmdRegistry.addBasicCommand(new IssueScanCommand(this));
+
+        GuildConfig.loadServerConfigs();
         permRegistry.save();
         PasteRequestModule.register(getPluginBus());
         new GHPRStatus(this);
         new GHIssueStatus(this);
         
-        cmdRegistry.addBasicCommand(new PRScanCommand());
-        cmdRegistry.addBasicCommand(new IssueScanCommand());
-
 
         getPluginBus().addListener(PluginMessageEvent.class, pm -> {
             if (pm.getMethod().equals("getDate")) {
@@ -275,7 +277,7 @@ public class MangoBotPlugin extends CorePlugin {
 
     public static String getToken() {
     	if (BOT_TOKEN.get().equals("empty")||BOT_TOKEN.get().equals("")) {
-    		System.out.println("Empty bot token, replace the bot token with the one from discord in"+CONFIG.location+ " or by typing it in here if you are not in gradle:");
+    		System.out.println("Empty bot token, replace the bot token with the one from discord in"+CONFIG.getFile()+ " or by typing it in here if you are not in gradle:");
     		Scanner scanner = new Scanner(System.in);
            if(scanner.hasNext()) {
     		String token = scanner.nextLine();
@@ -283,7 +285,7 @@ public class MangoBotPlugin extends CorePlugin {
             scanner.close();
             return token;
            }else {
-        	   System.out.println("Blank response, this is expected from being run within Gradle. You need to put your token here "+CONFIG.location);
+        	   System.out.println("Blank response, this is expected from being run within Gradle. You need to put your token here "+CONFIG.getFile());
           scanner.close();
            return BOT_TOKEN.get();
            }

--- a/src/main/java/org/mangorage/mangobot/MangoBotPlugin.java
+++ b/src/main/java/org/mangorage/mangobot/MangoBotPlugin.java
@@ -276,23 +276,24 @@ public class MangoBotPlugin extends CorePlugin {
     }
 
     public static String getToken() {
-    	if (BOT_TOKEN.get().equals("empty")||BOT_TOKEN.get().equals("")) {
-    		System.out.println("Empty bot token, replace the bot token with the one from discord in"+CONFIG.getFile()+ " or by typing it in here if you are not in gradle:");
-    		Scanner scanner = new Scanner(System.in);
-           if(scanner.hasNext()) {
-    		String token = scanner.nextLine();
-            BOT_TOKEN.set(token);
-            scanner.close();
-            return token;
-           }else {
-        	   System.out.println("Blank response, this is expected from being run within Gradle. You need to put your token here "+CONFIG.getFile());
-          scanner.close();
-           return BOT_TOKEN.get();
-           }
+		if (BOT_TOKEN.get().equals("empty") || BOT_TOKEN.get().equals("")) {
+			System.out.println("Empty bot token, replace the bot token with the one from discord in" + CONFIG.getFile() + " or by typing it in here if you are not in gradle:");
+			Scanner scanner = new Scanner(System.in);
 
-    	}else {
-    		return BOT_TOKEN.get();
-    	}
+			if (scanner.hasNext()) {
+				String token = scanner.nextLine();
+				BOT_TOKEN.set(token);
+				scanner.close();
+				return token;
+			} else {
+				System.out.println("Blank response, this is expected from being run within Gradle. You need to put your token here " + CONFIG.getFile());
+				scanner.close();
+				return BOT_TOKEN.get();
+			}
+
+		} else {
+			return BOT_TOKEN.get();
+		}
     }
 
 

--- a/src/main/java/org/mangorage/mangobot/config/GuildConfig.java
+++ b/src/main/java/org/mangorage/mangobot/config/GuildConfig.java
@@ -1,6 +1,7 @@
 package org.mangorage.mangobot.config;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.HashMap;
 
 import org.mangorage.basicutils.config.Config;
@@ -20,7 +21,7 @@ public class GuildConfig extends Config{
 	public ISetting<String> GIT_REPOS_ISSUE_SCANNED_CHANNELID = ConfigSetting.create(this, "GIT_REPOS_ISSUE_SCANNED_CHANNELID", "empty");
 
 	private GuildConfig(String guildID) {
-	super("config/"+guildID+"/","config.env");
+	super(Path.of("config/"+guildID+"/config.env"));
 	configs.put(guildID,this);
 	if(!GIT_REPOS_PR_SCANNED_CHANNELID.get().equals("empty")) {
 		GHPRStatus.indexed_channels.add(GIT_REPOS_PR_SCANNED_CHANNELID.get());	
@@ -36,13 +37,29 @@ public class GuildConfig extends Config{
 			return configs.get(guildID);
 		}
 		
-		File root = new File(MangoBotPlugin.CONFIG.location).getParentFile();
-		File path = new File("config/"+guildID+"/config.env");
+		Path root = MangoBotPlugin.CONFIG.getFile().getParent();
+		File path = new File(root+"/config/"+guildID+"/config.env");
 		path.getParentFile().mkdirs();
 		return new GuildConfig(guildID);
 	}
 
-	
+	public static void loadServerConfigs() {
+		Path root = MangoBotPlugin.CONFIG.getFile().getParent();
+		File path = new File(root+"/config/");
+		if (path.exists()) {
+            File[] listOfFiles = path.listFiles();
+            if (listOfFiles != null) {
+                for (File file : listOfFiles) {
+                    if (file.isDirectory()) {
+                    	guildsConfig(file.getName());
+                    }
+                }
+            }
+        } else {
+            System.out.println("No Guild Configs!");
+        }
+		
+	}
 	
 	
 }

--- a/src/main/java/org/mangorage/mangobot/config/GuildConfig.java
+++ b/src/main/java/org/mangorage/mangobot/config/GuildConfig.java
@@ -1,0 +1,48 @@
+package org.mangorage.mangobot.config;
+
+import java.io.File;
+import java.util.HashMap;
+
+import org.mangorage.basicutils.config.Config;
+import org.mangorage.basicutils.config.ConfigSetting;
+import org.mangorage.basicutils.config.ISetting;
+import org.mangorage.mangobot.MangoBotPlugin;
+import org.mangorage.mangobot.modules.github.GHIssueStatus;
+import org.mangorage.mangobot.modules.github.GHPRStatus;
+
+public class GuildConfig extends Config{
+
+	public static HashMap<String, GuildConfig> configs = new HashMap<String, GuildConfig>();
+
+	public ISetting<String> GIT_REPOS_PR_SCANNED = ConfigSetting.create(this, "GIT_REPOS_PR_SCANNED", "MinecraftForge/MinecraftForge,MangoRageBot/MangoBot,MangoRageBot/MangoBotPlugin,mikumikudanceminecraftmoddingdiscord/PMXMC");
+	public ISetting<String> GIT_REPOS_PR_SCANNED_CHANNELID = ConfigSetting.create(this, "GIT_REPOS_PR_SCANNED_CHANNELID", "empty");
+	public ISetting<String> GIT_REPOS_ISSUE_SCANNED = ConfigSetting.create(this, "GIT_REPOS_ISSUE_SCANNED", "MinecraftForge/MinecraftForge,MangoRageBot/MangoBot,MangoRageBot/MangoBotPlugin,mikumikudanceminecraftmoddingdiscord/PMXMC");
+	public ISetting<String> GIT_REPOS_ISSUE_SCANNED_CHANNELID = ConfigSetting.create(this, "GIT_REPOS_ISSUE_SCANNED_CHANNELID", "empty");
+
+	private GuildConfig(String guildID) {
+	super("config/"+guildID+"/","config.env");
+	configs.put(guildID,this);
+	if(!GIT_REPOS_PR_SCANNED_CHANNELID.get().equals("empty")) {
+		GHPRStatus.indexed_channels.add(GIT_REPOS_PR_SCANNED_CHANNELID.get());	
+	}
+	if(!GIT_REPOS_ISSUE_SCANNED_CHANNELID.get().equals("empty")) {
+		GHIssueStatus.indexed_channels.add(GIT_REPOS_ISSUE_SCANNED_CHANNELID.get());	
+	}
+	
+	}
+
+	public static GuildConfig guildsConfig(String guildID) {
+		if(configs.containsKey(guildID)) {
+			return configs.get(guildID);
+		}
+		
+		File root = new File(MangoBotPlugin.CONFIG.location).getParentFile();
+		File path = new File("config/"+guildID+"/config.env");
+		path.getParentFile().mkdirs();
+		return new GuildConfig(guildID);
+	}
+
+	
+	
+	
+}

--- a/src/main/java/org/mangorage/mangobot/config/GuildConfig.java
+++ b/src/main/java/org/mangorage/mangobot/config/GuildConfig.java
@@ -11,55 +11,58 @@ import org.mangorage.mangobot.MangoBotPlugin;
 import org.mangorage.mangobot.modules.github.GHIssueStatus;
 import org.mangorage.mangobot.modules.github.GHPRStatus;
 
-public class GuildConfig extends Config{
+
+public class GuildConfig extends Config {
 
 	public static HashMap<String, GuildConfig> configs = new HashMap<String, GuildConfig>();
-
 	public ISetting<String> GIT_REPOS_PR_SCANNED = ConfigSetting.create(this, "GIT_REPOS_PR_SCANNED", "MinecraftForge/MinecraftForge,MangoRageBot/MangoBot,MangoRageBot/MangoBotPlugin,mikumikudanceminecraftmoddingdiscord/PMXMC");
 	public ISetting<String> GIT_REPOS_PR_SCANNED_CHANNELID = ConfigSetting.create(this, "GIT_REPOS_PR_SCANNED_CHANNELID", "empty");
 	public ISetting<String> GIT_REPOS_ISSUE_SCANNED = ConfigSetting.create(this, "GIT_REPOS_ISSUE_SCANNED", "MinecraftForge/MinecraftForge,MangoRageBot/MangoBot,MangoRageBot/MangoBotPlugin,mikumikudanceminecraftmoddingdiscord/PMXMC");
 	public ISetting<String> GIT_REPOS_ISSUE_SCANNED_CHANNELID = ConfigSetting.create(this, "GIT_REPOS_ISSUE_SCANNED_CHANNELID", "empty");
 
 	private GuildConfig(String guildID) {
-	super(Path.of("config/"+guildID+"/config.env"));
-	configs.put(guildID,this);
-	if(!GIT_REPOS_PR_SCANNED_CHANNELID.get().equals("empty")) {
-		GHPRStatus.indexed_channels.add(GIT_REPOS_PR_SCANNED_CHANNELID.get());	
-	}
-	if(!GIT_REPOS_ISSUE_SCANNED_CHANNELID.get().equals("empty")) {
-		GHIssueStatus.indexed_channels.add(GIT_REPOS_ISSUE_SCANNED_CHANNELID.get());	
-	}
-	
+		super(Path.of("config/" + guildID + "/config.env"));
+		configs.put(guildID, this);
+
+		if (!GIT_REPOS_PR_SCANNED_CHANNELID.get().equals("empty")) {
+			GHPRStatus.indexed_channels.add(GIT_REPOS_PR_SCANNED_CHANNELID.get());
+		}
+
+		if (!GIT_REPOS_ISSUE_SCANNED_CHANNELID.get().equals("empty")) {
+			GHIssueStatus.indexed_channels.add(GIT_REPOS_ISSUE_SCANNED_CHANNELID.get());
+		}
+
 	}
 
 	public static GuildConfig guildsConfig(String guildID) {
-		if(configs.containsKey(guildID)) {
+		if (configs.containsKey(guildID)) {
 			return configs.get(guildID);
 		}
-		
+
 		Path root = MangoBotPlugin.CONFIG.getFile().getParent();
-		File path = new File(root+"/config/"+guildID+"/config.env");
+		File path = new File(root + "/config/" + guildID + "/config.env");
 		path.getParentFile().mkdirs();
 		return new GuildConfig(guildID);
 	}
 
 	public static void loadServerConfigs() {
 		Path root = MangoBotPlugin.CONFIG.getFile().getParent();
-		File path = new File(root+"/config/");
+		File path = new File(root + "/config/");
+
 		if (path.exists()) {
-            File[] listOfFiles = path.listFiles();
-            if (listOfFiles != null) {
-                for (File file : listOfFiles) {
-                    if (file.isDirectory()) {
-                    	guildsConfig(file.getName());
-                    }
-                }
-            }
-        } else {
-            System.out.println("No Guild Configs!");
-        }
-		
+			File[] listOfFiles = path.listFiles();
+
+			if (listOfFiles != null) {
+				for (File file: listOfFiles) {
+					if (file.isDirectory()) {
+						guildsConfig(file.getName());
+					}
+				}
+			}
+		} else {
+			System.out.println("No Guild Configs!");
+		}
+
 	}
-	
-	
+
 }

--- a/src/main/java/org/mangorage/mangobot/modules/github/GHIssueStatus.java
+++ b/src/main/java/org/mangorage/mangobot/modules/github/GHIssueStatus.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHIssueState;
 import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHRepository;
@@ -20,7 +21,7 @@ import org.mangorage.mangobot.MangoBotPlugin;
 import org.mangorage.mangobot.config.GuildConfig;
 import org.mangorage.mangobotapi.core.plugin.api.CorePlugin;
 
-public class GHPRStatus extends TimerTask {
+public class GHIssueStatus extends TimerTask {
 
 	public static ArrayList<String> indexed_channels = new ArrayList<String>();
 	
@@ -65,7 +66,7 @@ public class GHPRStatus extends TimerTask {
 
     private final CorePlugin corePlugin;
 
-    public GHPRStatus(CorePlugin corePlugin) {
+    public GHIssueStatus(CorePlugin corePlugin) {
         this.corePlugin = corePlugin;
         new Timer().scheduleAtFixedRate(this, 15 * 1000, 60 * 60 * 1000); // 60 minutes/1hr
     }
@@ -83,28 +84,28 @@ public class GHPRStatus extends TimerTask {
             	String guild = corePlugin.getJDA().getTextChannelById(chan).getGuild().getId();
             	GuildConfig config = GuildConfig.guildsConfig(guild);
             	String[] repos = config.GIT_REPOS_PR_SCANNED.get().split(",");
-            	int prs = 0;
+            	int issues = 0;
                 StringBuilder builder = new StringBuilder();
             	for (String repo:repos) {
             		int lastChecked = get(getFile(repo));
                     int number = lastChecked;
-                	List<GHPullRequest> PRS = new ArrayList<GHPullRequest>();
+                	List<GHIssue> ISSUES = new ArrayList<GHIssue>();
             		GHRepository repository = github.getRepository(repo);
-                     PRS.addAll(repository.getPullRequests(GHIssueState.OPEN).stream().filter(pr -> pr.getNumber() > lastChecked).toList());
-                     if(PRS.size()!=0) {
-                     prs = prs + PRS.size();
-                     builder.append("New "+ repo +" PR's: %s".formatted(PRS.size())).append("\n");
+            		ISSUES.addAll(repository.getIssues(GHIssueState.OPEN).stream().filter(pr -> pr.getNumber() > lastChecked).toList());
+                     if(ISSUES.size()!=0) {
+                     issues = issues + ISSUES.size();
+                     builder.append("New "+ repo +" Issue's: %s".formatted(ISSUES.size())).append("\n");
                 
-                     for (GHPullRequest PR : PRS) {
-                         System.out.println(PR.getNumber());
-                         if (PR.getNumber() > number)
-                             number = PR.getNumber();
+                     for (GHIssue issue : ISSUES) {
+                         System.out.println(issue.getNumber());
+                         if (issue.getNumber() > number)
+                             number = issue.getNumber();
                          builder.append(
                                  "- %s [%s](%s)"
                                          .formatted(
-                                                 PR.getTitle(),
-                                                 PR.getNumber(),
-                                                 PR.getHtmlUrl()
+                                        		 issue.getTitle(),
+                                                 issue.getNumber(),
+                                                 issue.getHtmlUrl()
                                          )
                          ).append("\n");
                      }
@@ -133,7 +134,7 @@ public class GHPRStatus extends TimerTask {
     }
     
     public Path getFile(String repo) {
-    	return corePlugin.getPluginDirectory().resolve("ghprstatus/"+repo.replace("/", ".")+".txt");
+    	return corePlugin.getPluginDirectory().resolve("ghissuestatus/"+repo.replace("/", ".")+".txt");
     }
     
     

--- a/src/main/java/org/mangorage/mangobot/modules/github/GHIssueStatus.java
+++ b/src/main/java/org/mangorage/mangobot/modules/github/GHIssueStatus.java
@@ -45,7 +45,7 @@ public class GHIssueStatus extends TimerTask {
     }
 
     public static int get(Path fileName) {
-        int result = 9743;
+        int result = 0;
         File file = fileName.toFile();
 
         // Check if the file exists before reading
@@ -73,13 +73,10 @@ public class GHIssueStatus extends TimerTask {
 
     @Override
     public void run() {
-        
-
         try {
             String token = MangoBotPlugin.GITHUB_TOKEN.get();
 
             GitHub github = GitHub.connect(MangoBotPlugin.GITHUB_USERNAME.get(), token);
-
             for(String chan:indexed_channels) {
             	String guild = corePlugin.getJDA().getTextChannelById(chan).getGuild().getId();
             	GuildConfig config = GuildConfig.guildsConfig(guild);
@@ -91,6 +88,8 @@ public class GHIssueStatus extends TimerTask {
                     int number = lastChecked;
                 	List<GHIssue> ISSUES = new ArrayList<GHIssue>();
             		GHRepository repository = github.getRepository(repo);
+            		repository.getIssues(GHIssueState.OPEN);
+            		repository.getIssues(GHIssueState.OPEN).stream();
             		ISSUES.addAll(repository.getIssues(GHIssueState.OPEN).stream().filter(pr -> pr.getNumber() > lastChecked).toList());
                      if(ISSUES.size()!=0) {
                      issues = issues + ISSUES.size();
@@ -117,9 +116,9 @@ public class GHIssueStatus extends TimerTask {
             	
             	
             	}
-            	
+            	if(!builder.isEmpty()) {
             	  corePlugin.getJDA().getTextChannelById(chan).sendMessage(builder).setSuppressEmbeds(true).queue();
-
+            	}
               
             	
 

--- a/src/main/java/org/mangorage/mangobot/modules/github/GHPRStatus.java
+++ b/src/main/java/org/mangorage/mangobot/modules/github/GHPRStatus.java
@@ -20,124 +20,119 @@ import org.mangorage.mangobot.MangoBotPlugin;
 import org.mangorage.mangobot.config.GuildConfig;
 import org.mangorage.mangobotapi.core.plugin.api.CorePlugin;
 
+
 public class GHPRStatus extends TimerTask {
 
 	public static ArrayList<String> indexed_channels = new ArrayList<String>();
-	
-    public static void save(int number, Path fileName) {
-        try {
-            File file = fileName.toFile();
 
-            // Create the file if it doesn't exist
-            if (!file.exists()) {
-                file.getParentFile().mkdirs();
-                file.createNewFile();
-            }
+	public static void save(int number, Path fileName) {
+		try {
+			File file = fileName.toFile();
 
-            try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
-                // Write the number to the file
-                writer.write(Integer.toString(number));
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
+			// Create the file if it doesn't exist
+			if (!file.exists()) {
+				file.getParentFile().mkdirs();
+				file.createNewFile();
+			}
 
-    public static int get(Path fileName) {
-        int result = 0;
-        File file = fileName.toFile();
+			try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
+				// Write the number to the file
+				writer.write(Integer.toString(number));
+			}
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
 
-        // Check if the file exists before reading
-        if (file.exists()) {
-            try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
-                // Read the number from the file
-                String line = reader.readLine();
-                if (line != null) {
-                    result = Integer.parseInt(line.trim());
-                }
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
+	public static int get(Path fileName) {
+		int result = 0;
+		File file = fileName.toFile();
 
-        return result;
-    }
+		// Check if the file exists before reading
+		if (file.exists()) {
+			try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+				// Read the number from the file
+				String line = reader.readLine();
 
-    private final CorePlugin corePlugin;
+				if (line != null) {
+					result = Integer.parseInt(line.trim());
+				}
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
 
-    public GHPRStatus(CorePlugin corePlugin) {
-        this.corePlugin = corePlugin;
-        new Timer().scheduleAtFixedRate(this, 15 * 1000, 60 * 60 * 1000); // 60 minutes/1hr
-    }
+		return result;
+	}
 
-    @Override
-    public void run() {
-        
+	private final CorePlugin corePlugin;
 
-        try {
-            String token = MangoBotPlugin.GITHUB_TOKEN.get();
+	public GHPRStatus(CorePlugin corePlugin) {
+		this.corePlugin = corePlugin;
+		new Timer().scheduleAtFixedRate(this, 15 * 1000, 60 * 60 * 1000); // 60 minutes/1hr
+	}
 
-            GitHub github = GitHub.connect(MangoBotPlugin.GITHUB_USERNAME.get(), token);
+	@Override
 
-            for(String chan:indexed_channels) {
-            	String guild = corePlugin.getJDA().getTextChannelById(chan).getGuild().getId();
-            	GuildConfig config = GuildConfig.guildsConfig(guild);
-            	String[] repos = config.GIT_REPOS_PR_SCANNED.get().split(",");
-            	int prs = 0;
-                StringBuilder builder = new StringBuilder();
-            	for (String repo:repos) {
-            		int lastChecked = get(getFile(repo));
-                    int number = lastChecked;
-                	List<GHPullRequest> PRS = new ArrayList<GHPullRequest>();
-            		GHRepository repository = github.getRepository(repo);
-                     PRS.addAll(repository.getPullRequests(GHIssueState.OPEN).stream().filter(pr -> pr.getNumber() > lastChecked).toList());
-                     if(PRS.size()!=0) {
-                     prs = prs + PRS.size();
-                     builder.append("New "+ repo +" PR's: %s".formatted(PRS.size())).append("\n");
-                
-                     for (GHPullRequest PR : PRS) {
-                         System.out.println(PR.getNumber());
-                         if (PR.getNumber() > number)
-                             number = PR.getNumber();
-                         builder.append(
-                                 "- %s [%s](%s)"
-                                         .formatted(
-                                                 PR.getTitle(),
-                                                 PR.getNumber(),
-                                                 PR.getHtmlUrl()
-                                         )
-                         ).append("\n");
-                     }
-                     
-                   
-                     save(number, getFile(repo));
+	public void run() {
 
-                     }
-            	
-            	
-            	}
-            	if(!builder.isEmpty()) {
-            	  corePlugin.getJDA().getTextChannelById(chan).sendMessage(builder).setSuppressEmbeds(true).queue();
-            	}
-              
-            	
+		try {
+			String token = MangoBotPlugin.GITHUB_TOKEN.get();
 
-            }
-            
+			GitHub github = GitHub.connect(MangoBotPlugin.GITHUB_USERNAME.get(), token);
 
+			for (String chan: indexed_channels) {
+				String guild = corePlugin.getJDA().getTextChannelById(chan).getGuild().getId();
+				GuildConfig config = GuildConfig.guildsConfig(guild);
+				String[] repos = config.GIT_REPOS_PR_SCANNED.get().split(",");
+				int prs = 0;
+				StringBuilder builder = new StringBuilder();
 
-           
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-    
-    public Path getFile(String repo) {
-    	return corePlugin.getPluginDirectory().resolve("ghprstatus/"+repo.replace("/", ".")+".txt");
-    }
-    
-    
-    
-    
-    
+				for (String repo: repos) {
+					int lastChecked = get(getFile(repo));
+					int number = lastChecked;
+					List<GHPullRequest> PRS = new ArrayList<GHPullRequest>();
+					GHRepository repository = github.getRepository(repo);
+					PRS.addAll(repository.getPullRequests(GHIssueState.OPEN).stream().filter(pr -> pr.getNumber() > lastChecked).toList());
+
+					if (PRS.size() != 0) {
+						prs = prs + PRS.size();
+						builder.append("New " + repo + " PR's: %s".formatted(PRS.size())).append("\n");
+
+						for (GHPullRequest PR: PRS) {
+							System.out.println(PR.getNumber());
+
+							if (PR.getNumber() > number)
+								number = PR.getNumber();
+							builder.append(
+								"- %s [%s](%s)"
+								.formatted(
+									PR.getTitle(),
+									PR.getNumber(),
+									PR.getHtmlUrl()
+								)
+							).append("\n");
+						}
+
+						save(number, getFile(repo));
+
+					}
+
+				}
+
+				if (!builder.isEmpty()) {
+					corePlugin.getJDA().getTextChannelById(chan).sendMessage(builder).setSuppressEmbeds(true).queue();
+				}
+
+			}
+
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	public Path getFile(String repo) {
+		return corePlugin.getPluginDirectory().resolve("ghprstatus/" + repo.replace("/", ".") + ".txt");
+	}
+
 }

--- a/src/main/java/org/mangorage/mangobot/modules/github/GHPRStatus.java
+++ b/src/main/java/org/mangorage/mangobot/modules/github/GHPRStatus.java
@@ -44,7 +44,7 @@ public class GHPRStatus extends TimerTask {
     }
 
     public static int get(Path fileName) {
-        int result = 9743;
+        int result = 0;
         File file = fileName.toFile();
 
         // Check if the file exists before reading
@@ -116,9 +116,9 @@ public class GHPRStatus extends TimerTask {
             	
             	
             	}
-            	
+            	if(!builder.isEmpty()) {
             	  corePlugin.getJDA().getTextChannelById(chan).sendMessage(builder).setSuppressEmbeds(true).queue();
-
+            	}
               
             	
 

--- a/src/main/java/org/mangorage/mangobot/modules/github/IssueScanCommand.java
+++ b/src/main/java/org/mangorage/mangobot/modules/github/IssueScanCommand.java
@@ -8,60 +8,77 @@ import org.mangorage.mangobot.core.BotPermissions;
 import org.mangorage.mangobotapi.core.commands.Arguments;
 import org.mangorage.mangobotapi.core.commands.CommandResult;
 import org.mangorage.mangobotapi.core.commands.IBasicCommand;
+import org.mangorage.mangobotapi.core.plugin.api.CorePlugin;
+import org.mangorage.mangobotapi.core.util.MessageSettings;
 
 import net.dv8tion.jda.api.entities.Message;
 
 public class IssueScanCommand implements IBasicCommand{
 
+    private final CorePlugin plugin;
+
+	public IssueScanCommand(CorePlugin plugin) {
+		this.plugin=plugin;
+	}
+	
+	
 	@Override
 	public CommandResult execute(Message message, Arguments args) {
 		// TODO Auto-generated method stub
+        MessageSettings dMessage = plugin.getMessageSettings();
+
         String type = args.get(0);
         String answer = args.get(1);
         GuildConfig guildConfig = GuildConfig.guildsConfig(message.getGuildId());
         
-        if (!BotPermissions.TRICK_ADMIN.hasPermission(message.getMember()))
-            return CommandResult.NO_PERMISSION;
-        
-        if(type!=null) {
+        if (!BotPermissions.TRICK_ADMIN.hasPermission(message.getMember())) {
+        	dMessage.apply(message.reply("No permission!")).queue();	
+         	return CommandResult.NO_PERMISSION;
+        }
+
+        if(!type.equals("")&&!type.equals(" ")) {
         	if(type.equals("-add")||type.equals("-追加")) {
         		String[] repos_arr =	guildConfig.GIT_REPOS_ISSUE_SCANNED.get().split(",");
         		ArrayList<String> repos = new ArrayList<String>(Arrays.asList(repos_arr));
         		repos.add(answer);
                 String result = String.join(",", repos);
                 guildConfig.GIT_REPOS_ISSUE_SCANNED.set(result);
-        		message.reply("Added: " + answer);
+            	dMessage.apply(message.reply("Added: " + answer)).queue();	
         	}else if(type.equals("-remove")||type.equals("-取り除く")){
             	String[] repos_arr =	guildConfig.GIT_REPOS_ISSUE_SCANNED.get().split(",");
         		ArrayList<String> repos = new ArrayList<String>(Arrays.asList(repos_arr));
         		repos.remove(answer);
                 String result = String.join(",", repos);
                 guildConfig.GIT_REPOS_ISSUE_SCANNED.set(result);
-        		message.reply("Removed: " + answer);
+            	dMessage.apply(message.reply("Removed: " + answer)).queue();	
         	}else if(type.equals("-list")||type.equals("-リスト")){
         	String[] repos =	guildConfig.GIT_REPOS_ISSUE_SCANNED.get().split(",");
         	StringBuilder builder = new StringBuilder();
         	for(String repo:repos) {
         		builder.append(repo+"\n");
         	}
-        	message.reply(builder);	
+        	dMessage.apply(message.reply(builder)).queue();	
         	}else if(type.equals("-setchannel")||type.equals("-チャンネルを設定する")){
         		GHIssueStatus.indexed_channels.remove(guildConfig.GIT_REPOS_ISSUE_SCANNED_CHANNELID.get());
+        		if(answer==null) {
+        		answer=message.getChannelId();	
+        		}
         		guildConfig.GIT_REPOS_ISSUE_SCANNED_CHANNELID.set(answer);
         		GHIssueStatus.indexed_channels.add(answer);
+            	dMessage.apply(message.reply("Set Channel")).queue();	
         	}else {
-        		message.reply("Invalid arg "+type);
+            	dMessage.apply(message.reply("Invalid arg "+type)).queue();	
         		return CommandResult.FAIL;
         	}
         	
         	
         }else {
-        	message.reply("PR Scan Command Usage:"
-        			+ "``!prscan -add Org/Repo`` Adds a Repository"
-        			+ "``!prscan -remove Org/Repo`` Removes a Repository"
-        			+ "``!prscan -list`` Lists Indexed Repository"
-        			+ "``!prscan -setchannel`` Sets this as the current channel to list the pull requests"
-        			);	
+        	dMessage.apply(message.reply("Issue Scan Command Usage:\n"
+        			+ "``!issuescan -add Org/Repo`` Adds a Repository\n"
+        			+ "``!issuescan -remove Org/Repo`` Removes a Repository\n"
+        			+ "``!issuescan -list`` Lists Indexed Repository\n"
+        			+ "``!issuescan -setchannel`` Sets this as the current channel to list the issues\n"
+        			)).queue();	
         }
 		
 		

--- a/src/main/java/org/mangorage/mangobot/modules/github/IssueScanCommand.java
+++ b/src/main/java/org/mangorage/mangobot/modules/github/IssueScanCommand.java
@@ -1,0 +1,76 @@
+package org.mangorage.mangobot.modules.github;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.mangorage.mangobot.config.GuildConfig;
+import org.mangorage.mangobot.core.BotPermissions;
+import org.mangorage.mangobotapi.core.commands.Arguments;
+import org.mangorage.mangobotapi.core.commands.CommandResult;
+import org.mangorage.mangobotapi.core.commands.IBasicCommand;
+
+import net.dv8tion.jda.api.entities.Message;
+
+public class IssueScanCommand implements IBasicCommand{
+
+	@Override
+	public CommandResult execute(Message message, Arguments args) {
+		// TODO Auto-generated method stub
+        String type = args.get(0);
+        String answer = args.get(1);
+        GuildConfig guildConfig = GuildConfig.guildsConfig(message.getGuildId());
+        
+        if (!BotPermissions.TRICK_ADMIN.hasPermission(message.getMember()))
+            return CommandResult.NO_PERMISSION;
+        
+        if(type!=null) {
+        	if(type.equals("-add")||type.equals("-追加")) {
+        		String[] repos_arr =	guildConfig.GIT_REPOS_ISSUE_SCANNED.get().split(",");
+        		ArrayList<String> repos = new ArrayList<String>(Arrays.asList(repos_arr));
+        		repos.add(answer);
+                String result = String.join(",", repos);
+                guildConfig.GIT_REPOS_ISSUE_SCANNED.set(result);
+        		message.reply("Added: " + answer);
+        	}else if(type.equals("-remove")||type.equals("-取り除く")){
+            	String[] repos_arr =	guildConfig.GIT_REPOS_ISSUE_SCANNED.get().split(",");
+        		ArrayList<String> repos = new ArrayList<String>(Arrays.asList(repos_arr));
+        		repos.remove(answer);
+                String result = String.join(",", repos);
+                guildConfig.GIT_REPOS_ISSUE_SCANNED.set(result);
+        		message.reply("Removed: " + answer);
+        	}else if(type.equals("-list")||type.equals("-リスト")){
+        	String[] repos =	guildConfig.GIT_REPOS_ISSUE_SCANNED.get().split(",");
+        	StringBuilder builder = new StringBuilder();
+        	for(String repo:repos) {
+        		builder.append(repo+"\n");
+        	}
+        	message.reply(builder);	
+        	}else if(type.equals("-setchannel")||type.equals("-チャンネルを設定する")){
+        		GHIssueStatus.indexed_channels.remove(guildConfig.GIT_REPOS_ISSUE_SCANNED_CHANNELID.get());
+        		guildConfig.GIT_REPOS_ISSUE_SCANNED_CHANNELID.set(answer);
+        		GHIssueStatus.indexed_channels.add(answer);
+        	}else {
+        		message.reply("Invalid arg "+type);
+        		return CommandResult.FAIL;
+        	}
+        	
+        	
+        }else {
+        	message.reply("PR Scan Command Usage:"
+        			+ "``!prscan -add Org/Repo`` Adds a Repository"
+        			+ "``!prscan -remove Org/Repo`` Removes a Repository"
+        			+ "``!prscan -list`` Lists Indexed Repository"
+        			+ "``!prscan -setchannel`` Sets this as the current channel to list the pull requests"
+        			);	
+        }
+		
+		
+		return CommandResult.PASS;
+	}
+
+	@Override
+	public String commandId() {
+		return "issuescan";
+	}
+
+}

--- a/src/main/java/org/mangorage/mangobot/modules/github/IssueScanCommand.java
+++ b/src/main/java/org/mangorage/mangobot/modules/github/IssueScanCommand.java
@@ -13,79 +13,83 @@ import org.mangorage.mangobotapi.core.util.MessageSettings;
 
 import net.dv8tion.jda.api.entities.Message;
 
-public class IssueScanCommand implements IBasicCommand{
 
-    private final CorePlugin plugin;
+public class IssueScanCommand implements IBasicCommand {
+
+	private final CorePlugin plugin;
 
 	public IssueScanCommand(CorePlugin plugin) {
-		this.plugin=plugin;
+		this.plugin = plugin;
 	}
-	
-	
+
 	@Override
+
 	public CommandResult execute(Message message, Arguments args) {
 		// TODO Auto-generated method stub
-        MessageSettings dMessage = plugin.getMessageSettings();
+		MessageSettings dMessage = plugin.getMessageSettings();
 
-        String type = args.get(0);
-        String answer = args.get(1);
-        GuildConfig guildConfig = GuildConfig.guildsConfig(message.getGuildId());
-        
-        if (!BotPermissions.TRICK_ADMIN.hasPermission(message.getMember())) {
-        	dMessage.apply(message.reply("No permission!")).queue();	
-         	return CommandResult.NO_PERMISSION;
-        }
+		String type = args.get(0);
+		String answer = args.get(1);
+		GuildConfig guildConfig = GuildConfig.guildsConfig(message.getGuildId());
 
-        if(!type.equals("")&&!type.equals(" ")) {
-        	if(type.equals("-add")||type.equals("-追加")) {
-        		String[] repos_arr =	guildConfig.GIT_REPOS_ISSUE_SCANNED.get().split(",");
-        		ArrayList<String> repos = new ArrayList<String>(Arrays.asList(repos_arr));
-        		repos.add(answer);
-                String result = String.join(",", repos);
-                guildConfig.GIT_REPOS_ISSUE_SCANNED.set(result);
-            	dMessage.apply(message.reply("Added: " + answer)).queue();	
-        	}else if(type.equals("-remove")||type.equals("-取り除く")){
-            	String[] repos_arr =	guildConfig.GIT_REPOS_ISSUE_SCANNED.get().split(",");
-        		ArrayList<String> repos = new ArrayList<String>(Arrays.asList(repos_arr));
-        		repos.remove(answer);
-                String result = String.join(",", repos);
-                guildConfig.GIT_REPOS_ISSUE_SCANNED.set(result);
-            	dMessage.apply(message.reply("Removed: " + answer)).queue();	
-        	}else if(type.equals("-list")||type.equals("-リスト")){
-        	String[] repos =	guildConfig.GIT_REPOS_ISSUE_SCANNED.get().split(",");
-        	StringBuilder builder = new StringBuilder();
-        	for(String repo:repos) {
-        		builder.append(repo+"\n");
-        	}
-        	dMessage.apply(message.reply(builder)).queue();	
-        	}else if(type.equals("-setchannel")||type.equals("-チャンネルを設定する")){
-        		GHIssueStatus.indexed_channels.remove(guildConfig.GIT_REPOS_ISSUE_SCANNED_CHANNELID.get());
-        		if(answer==null) {
-        		answer=message.getChannelId();	
-        		}
-        		guildConfig.GIT_REPOS_ISSUE_SCANNED_CHANNELID.set(answer);
-        		GHIssueStatus.indexed_channels.add(answer);
-            	dMessage.apply(message.reply("Set Channel")).queue();	
-        	}else {
-            	dMessage.apply(message.reply("Invalid arg "+type)).queue();	
-        		return CommandResult.FAIL;
-        	}
-        	
-        	
-        }else {
-        	dMessage.apply(message.reply("Issue Scan Command Usage:\n"
-        			+ "``!issuescan -add Org/Repo`` Adds a Repository\n"
-        			+ "``!issuescan -remove Org/Repo`` Removes a Repository\n"
-        			+ "``!issuescan -list`` Lists Indexed Repository\n"
-        			+ "``!issuescan -setchannel`` Sets this as the current channel to list the issues\n"
-        			)).queue();	
-        }
-		
-		
+		if (!BotPermissions.TRICK_ADMIN.hasPermission(message.getMember())) {
+			dMessage.apply(message.reply("No permission!")).queue();
+			return CommandResult.NO_PERMISSION;
+		}
+
+		if (!type.equals("") && !type.equals(" ")) {
+			if (type.equals("-add") || type.equals("-追加")) {
+				String[] repos_arr = guildConfig.GIT_REPOS_ISSUE_SCANNED.get().split(",");
+				ArrayList<String> repos = new ArrayList<String> (Arrays.asList(repos_arr));
+				repos.add(answer);
+				String result = String.join(",", repos);
+				guildConfig.GIT_REPOS_ISSUE_SCANNED.set(result);
+				dMessage.apply(message.reply("Added: " + answer)).queue();
+			} else if (type.equals("-remove") || type.equals("-取り除く")) {
+				String[] repos_arr = guildConfig.GIT_REPOS_ISSUE_SCANNED.get().split(",");
+				ArrayList<String> repos = new ArrayList<String> (Arrays.asList(repos_arr));
+				repos.remove(answer);
+				String result = String.join(",", repos);
+				guildConfig.GIT_REPOS_ISSUE_SCANNED.set(result);
+				dMessage.apply(message.reply("Removed: " + answer)).queue();
+			} else if (type.equals("-list") || type.equals("-リスト")) {
+				String[] repos = guildConfig.GIT_REPOS_ISSUE_SCANNED.get().split(",");
+				StringBuilder builder = new StringBuilder();
+
+				for (String repo: repos) {
+					builder.append(repo + "\n");
+				}
+
+				dMessage.apply(message.reply(builder)).queue();
+			} else if (type.equals("-setchannel") || type.equals("-チャンネルを設定する")) {
+				GHIssueStatus.indexed_channels.remove(guildConfig.GIT_REPOS_ISSUE_SCANNED_CHANNELID.get());
+
+				if (answer == null) {
+					answer = message.getChannelId();
+				}
+
+				guildConfig.GIT_REPOS_ISSUE_SCANNED_CHANNELID.set(answer);
+				GHIssueStatus.indexed_channels.add(answer);
+				dMessage.apply(message.reply("Set Channel")).queue();
+			} else {
+				dMessage.apply(message.reply("Invalid arg " + type)).queue();
+				return CommandResult.FAIL;
+			}
+
+		} else {
+			dMessage.apply(message.reply("Issue Scan Command Usage:\n" +
+				"``!issuescan -add Org/Repo`` Adds a Repository\n" +
+				"``!issuescan -remove Org/Repo`` Removes a Repository\n" +
+				"``!issuescan -list`` Lists Indexed Repository\n" +
+				"``!issuescan -setchannel`` Sets this as the current channel to list the issues\n"
+			)).queue();
+		}
+
 		return CommandResult.PASS;
 	}
 
 	@Override
+
 	public String commandId() {
 		return "issuescan";
 	}

--- a/src/main/java/org/mangorage/mangobot/modules/github/PRScanCommand.java
+++ b/src/main/java/org/mangorage/mangobot/modules/github/PRScanCommand.java
@@ -13,79 +13,82 @@ import org.mangorage.mangobotapi.core.util.MessageSettings;
 
 import net.dv8tion.jda.api.entities.Message;
 
-public class PRScanCommand implements IBasicCommand{
 
-    private final CorePlugin plugin;
+public class PRScanCommand implements IBasicCommand {
+
+	private final CorePlugin plugin;
 
 	public PRScanCommand(CorePlugin plugin) {
-		this.plugin=plugin;
+		this.plugin = plugin;
 	}
-	
-	
+
 	@Override
+
 	public CommandResult execute(Message message, Arguments args) {
-		// TODO Auto-generated method stub
-        MessageSettings dMessage = plugin.getMessageSettings();
+		MessageSettings dMessage = plugin.getMessageSettings();
 
-        String type = args.get(0);
-        String answer = args.get(1);
-        GuildConfig guildConfig = GuildConfig.guildsConfig(message.getGuildId());
-        
-        if (!BotPermissions.TRICK_ADMIN.hasPermission(message.getMember())) {
-        	dMessage.apply(message.reply("No permission!")).queue();	
-         	return CommandResult.NO_PERMISSION;
-        }
+		String type = args.get(0);
+		String answer = args.get(1);
+		GuildConfig guildConfig = GuildConfig.guildsConfig(message.getGuildId());
 
-        if(!type.equals("")&&!type.equals(" ")) {
-        	if(type.equals("-add")||type.equals("-追加")) {
-        		String[] repos_arr =	guildConfig.GIT_REPOS_PR_SCANNED.get().split(",");
-        		ArrayList<String> repos = new ArrayList<String>(Arrays.asList(repos_arr));
-        		repos.add(answer);
-                String result = String.join(",", repos);
-                guildConfig.GIT_REPOS_PR_SCANNED.set(result);
-            	dMessage.apply(message.reply("Added: " + answer)).queue();	
-        	}else if(type.equals("-remove")||type.equals("-取り除く")){
-            	String[] repos_arr =	guildConfig.GIT_REPOS_PR_SCANNED.get().split(",");
-        		ArrayList<String> repos = new ArrayList<String>(Arrays.asList(repos_arr));
-        		repos.remove(answer);
-                String result = String.join(",", repos);
-                guildConfig.GIT_REPOS_PR_SCANNED.set(result);
-            	dMessage.apply(message.reply("Removed: " + answer)).queue();	
-        	}else if(type.equals("-list")||type.equals("-リスト")){
-        	String[] repos =	guildConfig.GIT_REPOS_PR_SCANNED.get().split(",");
-        	StringBuilder builder = new StringBuilder();
-        	for(String repo:repos) {
-        		builder.append(repo+"\n");
-        	}
-        	dMessage.apply(message.reply(builder)).queue();	
-        	}else if(type.equals("-setchannel")||type.equals("-チャンネルを設定する")){
-        		GHPRStatus.indexed_channels.remove(guildConfig.GIT_REPOS_PR_SCANNED_CHANNELID.get());
-        		if(answer==null) {
-        		answer=message.getChannelId();	
-        		}
-        		guildConfig.GIT_REPOS_PR_SCANNED_CHANNELID.set(answer);
-        		GHPRStatus.indexed_channels.add(answer);
-            	dMessage.apply(message.reply("Set Channel")).queue();	
-        	}else {
-            	dMessage.apply(message.reply("Invalid arg "+type)).queue();	
-        		return CommandResult.FAIL;
-        	}
-        	
-        	
-        }else {
-        	dMessage.apply(message.reply("PR Scan Command Usage:\n"
-        			+ "``!prscan -add Org/Repo`` Adds a Repository\n"
-        			+ "``!prscan -remove Org/Repo`` Removes a Repository\n"
-        			+ "``!prscan -list`` Lists Indexed Repository\n"
-        			+ "``!prscan -setchannel`` Sets this as the current channel to list the pull requests\n"
-        			)).queue();	
-        }
-		
-		
+		if (!BotPermissions.TRICK_ADMIN.hasPermission(message.getMember())) {
+			dMessage.apply(message.reply("No permission!")).queue();
+			return CommandResult.NO_PERMISSION;
+		}
+
+		if (!type.equals("") && !type.equals(" ")) {
+			if (type.equals("-add") || type.equals("-追加")) {
+				String[] repos_arr = guildConfig.GIT_REPOS_PR_SCANNED.get().split(",");
+				ArrayList<String> repos = new ArrayList<String> (Arrays.asList(repos_arr));
+				repos.add(answer);
+				String result = String.join(",", repos);
+				guildConfig.GIT_REPOS_PR_SCANNED.set(result);
+				dMessage.apply(message.reply("Added: " + answer)).queue();
+			} else if (type.equals("-remove") || type.equals("-取り除く")) {
+				String[] repos_arr = guildConfig.GIT_REPOS_PR_SCANNED.get().split(",");
+				ArrayList<String> repos = new ArrayList<String> (Arrays.asList(repos_arr));
+				repos.remove(answer);
+				String result = String.join(",", repos);
+				guildConfig.GIT_REPOS_PR_SCANNED.set(result);
+				dMessage.apply(message.reply("Removed: " + answer)).queue();
+			} else if (type.equals("-list") || type.equals("-リスト")) {
+				String[] repos = guildConfig.GIT_REPOS_PR_SCANNED.get().split(",");
+				StringBuilder builder = new StringBuilder();
+
+				for (String repo: repos) {
+					builder.append(repo + "\n");
+				}
+
+				dMessage.apply(message.reply(builder)).queue();
+			} else if (type.equals("-setchannel") || type.equals("-チャンネルを設定する")) {
+				GHPRStatus.indexed_channels.remove(guildConfig.GIT_REPOS_PR_SCANNED_CHANNELID.get());
+
+				if (answer == null) {
+					answer = message.getChannelId();
+				}
+
+				guildConfig.GIT_REPOS_PR_SCANNED_CHANNELID.set(answer);
+				GHPRStatus.indexed_channels.add(answer);
+				dMessage.apply(message.reply("Set Channel")).queue();
+			} else {
+				dMessage.apply(message.reply("Invalid arg " + type)).queue();
+				return CommandResult.FAIL;
+			}
+
+		} else {
+			dMessage.apply(message.reply("PR Scan Command Usage:\n" +
+				"``!prscan -add Org/Repo`` Adds a Repository\n" +
+				"``!prscan -remove Org/Repo`` Removes a Repository\n" +
+				"``!prscan -list`` Lists Indexed Repository\n" +
+				"``!prscan -setchannel`` Sets this as the current channel to list the pull requests\n"
+			)).queue();
+		}
+
 		return CommandResult.PASS;
 	}
 
 	@Override
+
 	public String commandId() {
 		return "prscan";
 	}

--- a/src/main/java/org/mangorage/mangobot/modules/github/PRScanCommand.java
+++ b/src/main/java/org/mangorage/mangobot/modules/github/PRScanCommand.java
@@ -1,0 +1,76 @@
+package org.mangorage.mangobot.modules.github;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.mangorage.mangobot.config.GuildConfig;
+import org.mangorage.mangobot.core.BotPermissions;
+import org.mangorage.mangobotapi.core.commands.Arguments;
+import org.mangorage.mangobotapi.core.commands.CommandResult;
+import org.mangorage.mangobotapi.core.commands.IBasicCommand;
+
+import net.dv8tion.jda.api.entities.Message;
+
+public class PRScanCommand implements IBasicCommand{
+
+	@Override
+	public CommandResult execute(Message message, Arguments args) {
+		// TODO Auto-generated method stub
+        String type = args.get(0);
+        String answer = args.get(1);
+        GuildConfig guildConfig = GuildConfig.guildsConfig(message.getGuildId());
+        
+        if (!BotPermissions.TRICK_ADMIN.hasPermission(message.getMember()))
+            return CommandResult.NO_PERMISSION;
+        
+        if(type!=null) {
+        	if(type.equals("-add")||type.equals("-追加")) {
+        		String[] repos_arr =	guildConfig.GIT_REPOS_PR_SCANNED.get().split(",");
+        		ArrayList<String> repos = new ArrayList<String>(Arrays.asList(repos_arr));
+        		repos.add(answer);
+                String result = String.join(",", repos);
+                guildConfig.GIT_REPOS_PR_SCANNED.set(result);
+        		message.reply("Added: " + answer);
+        	}else if(type.equals("-remove")||type.equals("-取り除く")){
+            	String[] repos_arr =	guildConfig.GIT_REPOS_PR_SCANNED.get().split(",");
+        		ArrayList<String> repos = new ArrayList<String>(Arrays.asList(repos_arr));
+        		repos.remove(answer);
+                String result = String.join(",", repos);
+                guildConfig.GIT_REPOS_PR_SCANNED.set(result);
+        		message.reply("Removed: " + answer);
+        	}else if(type.equals("-list")||type.equals("-リスト")){
+        	String[] repos =	guildConfig.GIT_REPOS_PR_SCANNED.get().split(",");
+        	StringBuilder builder = new StringBuilder();
+        	for(String repo:repos) {
+        		builder.append(repo+"\n");
+        	}
+        	message.reply(builder);	
+        	}else if(type.equals("-setchannel")||type.equals("-チャンネルを設定する")){
+        		GHPRStatus.indexed_channels.remove(guildConfig.GIT_REPOS_PR_SCANNED_CHANNELID.get());
+        		guildConfig.GIT_REPOS_PR_SCANNED_CHANNELID.set(answer);
+        		GHPRStatus.indexed_channels.add(answer);
+        	}else {
+        		message.reply("Invalid arg "+type);
+        		return CommandResult.FAIL;
+        	}
+        	
+        	
+        }else {
+        	message.reply("PR Scan Command Usage:"
+        			+ "``!prscan -add Org/Repo`` Adds a Repository"
+        			+ "``!prscan -remove Org/Repo`` Removes a Repository"
+        			+ "``!prscan -list`` Lists Indexed Repository"
+        			+ "``!prscan -setchannel`` Sets this as the current channel to list the pull requests"
+        			);	
+        }
+		
+		
+		return CommandResult.PASS;
+	}
+
+	@Override
+	public String commandId() {
+		return "prscan";
+	}
+
+}

--- a/src/main/java/org/mangorage/mangobot/modules/github/PRScanCommand.java
+++ b/src/main/java/org/mangorage/mangobot/modules/github/PRScanCommand.java
@@ -8,60 +8,77 @@ import org.mangorage.mangobot.core.BotPermissions;
 import org.mangorage.mangobotapi.core.commands.Arguments;
 import org.mangorage.mangobotapi.core.commands.CommandResult;
 import org.mangorage.mangobotapi.core.commands.IBasicCommand;
+import org.mangorage.mangobotapi.core.plugin.api.CorePlugin;
+import org.mangorage.mangobotapi.core.util.MessageSettings;
 
 import net.dv8tion.jda.api.entities.Message;
 
 public class PRScanCommand implements IBasicCommand{
 
+    private final CorePlugin plugin;
+
+	public PRScanCommand(CorePlugin plugin) {
+		this.plugin=plugin;
+	}
+	
+	
 	@Override
 	public CommandResult execute(Message message, Arguments args) {
 		// TODO Auto-generated method stub
+        MessageSettings dMessage = plugin.getMessageSettings();
+
         String type = args.get(0);
         String answer = args.get(1);
         GuildConfig guildConfig = GuildConfig.guildsConfig(message.getGuildId());
         
-        if (!BotPermissions.TRICK_ADMIN.hasPermission(message.getMember()))
-            return CommandResult.NO_PERMISSION;
-        
-        if(type!=null) {
+        if (!BotPermissions.TRICK_ADMIN.hasPermission(message.getMember())) {
+        	dMessage.apply(message.reply("No permission!")).queue();	
+         	return CommandResult.NO_PERMISSION;
+        }
+
+        if(!type.equals("")&&!type.equals(" ")) {
         	if(type.equals("-add")||type.equals("-追加")) {
         		String[] repos_arr =	guildConfig.GIT_REPOS_PR_SCANNED.get().split(",");
         		ArrayList<String> repos = new ArrayList<String>(Arrays.asList(repos_arr));
         		repos.add(answer);
                 String result = String.join(",", repos);
                 guildConfig.GIT_REPOS_PR_SCANNED.set(result);
-        		message.reply("Added: " + answer);
+            	dMessage.apply(message.reply("Added: " + answer)).queue();	
         	}else if(type.equals("-remove")||type.equals("-取り除く")){
             	String[] repos_arr =	guildConfig.GIT_REPOS_PR_SCANNED.get().split(",");
         		ArrayList<String> repos = new ArrayList<String>(Arrays.asList(repos_arr));
         		repos.remove(answer);
                 String result = String.join(",", repos);
                 guildConfig.GIT_REPOS_PR_SCANNED.set(result);
-        		message.reply("Removed: " + answer);
+            	dMessage.apply(message.reply("Removed: " + answer)).queue();	
         	}else if(type.equals("-list")||type.equals("-リスト")){
         	String[] repos =	guildConfig.GIT_REPOS_PR_SCANNED.get().split(",");
         	StringBuilder builder = new StringBuilder();
         	for(String repo:repos) {
         		builder.append(repo+"\n");
         	}
-        	message.reply(builder);	
+        	dMessage.apply(message.reply(builder)).queue();	
         	}else if(type.equals("-setchannel")||type.equals("-チャンネルを設定する")){
         		GHPRStatus.indexed_channels.remove(guildConfig.GIT_REPOS_PR_SCANNED_CHANNELID.get());
+        		if(answer==null) {
+        		answer=message.getChannelId();	
+        		}
         		guildConfig.GIT_REPOS_PR_SCANNED_CHANNELID.set(answer);
         		GHPRStatus.indexed_channels.add(answer);
+            	dMessage.apply(message.reply("Set Channel")).queue();	
         	}else {
-        		message.reply("Invalid arg "+type);
+            	dMessage.apply(message.reply("Invalid arg "+type)).queue();	
         		return CommandResult.FAIL;
         	}
         	
         	
         }else {
-        	message.reply("PR Scan Command Usage:"
-        			+ "``!prscan -add Org/Repo`` Adds a Repository"
-        			+ "``!prscan -remove Org/Repo`` Removes a Repository"
-        			+ "``!prscan -list`` Lists Indexed Repository"
-        			+ "``!prscan -setchannel`` Sets this as the current channel to list the pull requests"
-        			);	
+        	dMessage.apply(message.reply("PR Scan Command Usage:\n"
+        			+ "``!prscan -add Org/Repo`` Adds a Repository\n"
+        			+ "``!prscan -remove Org/Repo`` Removes a Repository\n"
+        			+ "``!prscan -list`` Lists Indexed Repository\n"
+        			+ "``!prscan -setchannel`` Sets this as the current channel to list the pull requests\n"
+        			)).queue();	
         }
 		
 		

--- a/src/main/java/org/mangorage/mangobot/modules/github/PasteRequestModule.java
+++ b/src/main/java/org/mangorage/mangobot/modules/github/PasteRequestModule.java
@@ -46,10 +46,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class PasteRequestModule {
-    private static final LazyReference<GitHubClient> GITHUB_CLIENT = LazyReference.create(() -> new GitHubClient().setOAuth2Token(MangoBotPlugin.PASTE_TOKEN.get()));
+    private static final LazyReference<GitHubClient> GITHUB_CLIENT = LazyReference.create(() -> new GitHubClient().setOAuth2Token(MangoBotPlugin.GITHUB_TOKEN.get()));
     private static final List<String> GUILDS = List.of(
             "1129059589325852724",
-            "834300742864601088"
+            "834300742864601088",
+            "1179586337431633991"
     );
     private static final Emoji EMOJI = Emoji.fromUnicode("\uD83D\uDCCB");
 

--- a/src/main/resources/installerdata/deps.txt
+++ b/src/main/resources/installerdata/deps.txt
@@ -1,6 +1,0 @@
-https://repo.maven.apache.org/maven2/ org.kohsuke github-api 1.123 github-api-1.123.jar
-https://repo.maven.apache.org/maven2/ org.apache.commons commons-lang3 3.9 commons-lang3-3.9.jar
-https://repo.maven.apache.org/maven2/ com.fasterxml.jackson.core jackson-databind 2.12.1 jackson-databind-2.12.1.jar
-https://repo.maven.apache.org/maven2/ com.fasterxml.jackson.core jackson-annotations 2.12.1 jackson-annotations-2.12.1.jar
-https://repo.maven.apache.org/maven2/ com.fasterxml.jackson.core jackson-core 2.12.1 jackson-core-2.12.1.jar
-https://repo.maven.apache.org/maven2/ commons-io commons-io 2.4 commons-io-2.4.jar

--- a/src/main/resources/installerdata/deps.txt
+++ b/src/main/resources/installerdata/deps.txt
@@ -1,3 +1,6 @@
 https://repo.maven.apache.org/maven2/ org.kohsuke github-api 1.123 github-api-1.123.jar
 https://repo.maven.apache.org/maven2/ org.apache.commons commons-lang3 3.9 commons-lang3-3.9.jar
+https://repo.maven.apache.org/maven2/ com.fasterxml.jackson.core jackson-databind 2.12.1 jackson-databind-2.12.1.jar
+https://repo.maven.apache.org/maven2/ com.fasterxml.jackson.core jackson-annotations 2.12.1 jackson-annotations-2.12.1.jar
+https://repo.maven.apache.org/maven2/ com.fasterxml.jackson.core jackson-core 2.12.1 jackson-core-2.12.1.jar
 https://repo.maven.apache.org/maven2/ commons-io commons-io 2.4 commons-io-2.4.jar

--- a/src/main/resources/installerdata/deps.txt
+++ b/src/main/resources/installerdata/deps.txt
@@ -1,6 +1,3 @@
 https://repo.maven.apache.org/maven2/ org.kohsuke github-api 1.123 github-api-1.123.jar
 https://repo.maven.apache.org/maven2/ org.apache.commons commons-lang3 3.9 commons-lang3-3.9.jar
-https://repo.maven.apache.org/maven2/ com.fasterxml.jackson.core jackson-databind 2.12.1 jackson-databind-2.12.1.jar
-https://repo.maven.apache.org/maven2/ com.fasterxml.jackson.core jackson-annotations 2.12.1 jackson-annotations-2.12.1.jar
-https://repo.maven.apache.org/maven2/ com.fasterxml.jackson.core jackson-core 2.12.1 jackson-core-2.12.1.jar
 https://repo.maven.apache.org/maven2/ commons-io commons-io 2.4 commons-io-2.4.jar

--- a/src/main/resources/installerdata/deps.txt
+++ b/src/main/resources/installerdata/deps.txt
@@ -1,0 +1,6 @@
+https://repo.maven.apache.org/maven2/ org.kohsuke github-api 1.123 github-api-1.123.jar
+https://repo.maven.apache.org/maven2/ org.apache.commons commons-lang3 3.9 commons-lang3-3.9.jar
+https://repo.maven.apache.org/maven2/ com.fasterxml.jackson.core jackson-databind 2.12.1 jackson-databind-2.12.1.jar
+https://repo.maven.apache.org/maven2/ com.fasterxml.jackson.core jackson-annotations 2.12.1 jackson-annotations-2.12.1.jar
+https://repo.maven.apache.org/maven2/ com.fasterxml.jackson.core jackson-core 2.12.1 jackson-core-2.12.1.jar
+https://repo.maven.apache.org/maven2/ commons-io commons-io 2.4 commons-io-2.4.jar


### PR DESCRIPTION
![settingchannel](https://github.com/MangoRageBot/MangoBotPlugin/assets/153419899/1894dd30-232c-4724-aae1-7292b87b1e16)
![issuescancommand](https://github.com/MangoRageBot/MangoBotPlugin/assets/153419899/6b7882e5-9d2b-439e-a2f0-488ea8841c46)
![addingremovingissues](https://github.com/MangoRageBot/MangoBotPlugin/assets/153419899/ef601638-b3c6-499c-a16c-6a64d70d3a70)
![issues_listed](https://github.com/MangoRageBot/MangoBotPlugin/assets/153419899/ab077ea8-0a5b-472b-a9c8-35f5f00e3bd7)



I have made a system allowing for you to scan multiple GitHub repositories for issues and PRs. You just need to set the channel with the !issuescan -setchannel command for issues or !prscan -setchannel for PRs as shown in the picture and then you can add or remove repositories and it will be added to your server config.

BTW there is an issue where there are 2 conflicting versions of Jackson, 2.12 and 2.15, I tried to fix it but to no avail, you may want to look into that.
