### PR TITLE
Add LogAnalyser

### DIFF
--- a/src/main/java/org/mangorage/mangobot/core/Util.java
+++ b/src/main/java/org/mangorage/mangobot/core/Util.java
@@ -151,12 +151,16 @@ public class Util {
   //Copied from FCIGenUtils.java
     public static String getStringFromInputStream(InputStream inputStream) throws IOException {
         BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+        String nl = System.getProperty("line.separator");
         String line;
         StringBuilder stringBuilder = new StringBuilder();
         while ((line = bufferedReader.readLine()) != null) {
-            stringBuilder.append(line);
+            stringBuilder.append(line+nl);
         }
         return stringBuilder.toString();
     }
+    
+    
+    
     
 }

--- a/src/main/java/org/mangorage/mangobot/core/Util.java
+++ b/src/main/java/org/mangorage/mangobot/core/Util.java
@@ -32,8 +32,15 @@ import org.mangorage.mangobotapi.core.commands.Arguments;
 import org.mangorage.mangobotapi.core.commands.CommandPrefix;
 import org.mangorage.mangobotapi.core.events.BasicCommandEvent;
 import org.mangorage.mangobotapi.core.plugin.api.CorePlugin;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -107,4 +114,36 @@ public class Util {
         }
         return true;
     }
+    
+    //Copied from FCIGenUtils.java
+    public static InputStream getFileInputStream(String fileUrl) {  
+        try {  
+            URL url = new URL(fileUrl);  
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();  
+            connection.setRequestMethod("GET");  
+  
+            int responseCode = connection.getResponseCode();  
+            if (responseCode == HttpURLConnection.HTTP_OK) {  
+                InputStream inputStream = new BufferedInputStream(connection.getInputStream());  
+                ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();  
+                byte[] buffer = new byte[1024];  
+                int bytesRead;  
+                while ((bytesRead = inputStream.read(buffer)) != -1) {  
+                    byteArrayOutputStream.write(buffer, 0, bytesRead);  
+                }  
+                byte[] byteArray = byteArrayOutputStream.toByteArray();  
+                  
+                byteArrayOutputStream.close();  
+                inputStream.close();  
+                  
+                return new ByteArrayInputStream(byteArray);  
+            } else {  
+                throw new IOException("Server response code: " + responseCode);  
+            }  
+        } catch (IOException e) {  
+            e.printStackTrace();  
+            return null;
+        }  
+    }  
+    
 }

--- a/src/main/java/org/mangorage/mangobot/core/Util.java
+++ b/src/main/java/org/mangorage/mangobot/core/Util.java
@@ -34,10 +34,12 @@ import org.mangorage.mangobotapi.core.events.BasicCommandEvent;
 import org.mangorage.mangobotapi.core.plugin.api.CorePlugin;
 
 import java.io.BufferedInputStream;
+import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -144,6 +146,17 @@ public class Util {
             e.printStackTrace();  
             return null;
         }  
-    }  
+    }
+    
+  //Copied from FCIGenUtils.java
+    public static String getStringFromInputStream(InputStream inputStream) throws IOException {
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+        String line;
+        StringBuilder stringBuilder = new StringBuilder();
+        while ((line = bufferedReader.readLine()) != null) {
+            stringBuilder.append(line);
+        }
+        return stringBuilder.toString();
+    }
     
 }

--- a/src/main/java/org/mangorage/mangobot/modules/github/PasteRequestModule.java
+++ b/src/main/java/org/mangorage/mangobot/modules/github/PasteRequestModule.java
@@ -32,6 +32,7 @@ import org.eclipse.egit.github.core.service.GistService;
 import org.mangorage.basicutils.TaskScheduler;
 import org.mangorage.basicutils.misc.LazyReference;
 import org.mangorage.mangobot.MangoBotPlugin;
+import org.mangorage.mangobot.modules.logs.LogAnalyser;
 import org.mangorage.mangobotapi.core.events.discord.DMessageReceivedEvent;
 import org.mangorage.mangobotapi.core.events.discord.DReactionEvent;
 import org.mangorage.mboteventbus.impl.IEventBus;
@@ -152,6 +153,7 @@ public class PasteRequestModule {
         var dEvent = event.get();
         var message = dEvent.getMessage();
         var attachments = message.getAttachments();
+        LogAnalyser.scanMessage(message);
         if (!attachments.isEmpty()) {
             TaskScheduler.getExecutor().execute(() -> {
                 var suceeeded = new AtomicBoolean(false);
@@ -162,6 +164,7 @@ public class PasteRequestModule {
                         String content = new String(bytes, StandardCharsets.UTF_8);
                         if (containsPrintableCharacters(content)) {
                             suceeeded.set(true);
+                            LogAnalyser.readLog(message, content);
                             break;
                         }
                     } catch (InterruptedException | ExecutionException e) {
@@ -169,7 +172,10 @@ public class PasteRequestModule {
                     }
                 }
 
-                if (suceeeded.get()) message.addReaction(EMOJI).queue();
+                if (suceeeded.get()) { 
+                	message.addReaction(EMOJI).queue();	
+                }
+            
             });
         }
     }

--- a/src/main/java/org/mangorage/mangobot/modules/github/PasteRequestModule.java
+++ b/src/main/java/org/mangorage/mangobot/modules/github/PasteRequestModule.java
@@ -172,10 +172,7 @@ public class PasteRequestModule {
                     }
                 }
 
-                if (suceeeded.get()) { 
-                	message.addReaction(EMOJI).queue();	
-                }
-            
+                if (suceeeded.get()) message.addReaction(EMOJI).queue();
             });
         }
     }

--- a/src/main/java/org/mangorage/mangobot/modules/github/PasteRequestModule.java
+++ b/src/main/java/org/mangorage/mangobot/modules/github/PasteRequestModule.java
@@ -159,13 +159,12 @@ public class PasteRequestModule {
                 var suceeeded = new AtomicBoolean(false);
                 for (Message.Attachment attachment : attachments) {
                     try {
-                    	InputStream stream = attachment.getProxy().download().get();
-                        byte[] bytes = getData(stream);
+                        byte[] bytes = getData(attachment.getProxy().download().get());
                         if (bytes == null) continue;
                         String content = new String(bytes, StandardCharsets.UTF_8);
                         if (containsPrintableCharacters(content)) {
                             suceeeded.set(true);
-                            LogAnalyser.readLog(message, stream);
+                            LogAnalyser.readLog(message, content);
                             break;
                         }
                     } catch (InterruptedException | ExecutionException e) {

--- a/src/main/java/org/mangorage/mangobot/modules/github/PasteRequestModule.java
+++ b/src/main/java/org/mangorage/mangobot/modules/github/PasteRequestModule.java
@@ -96,7 +96,10 @@ public class PasteRequestModule {
     public static void createGists(Message msg, User requester) {
         TaskScheduler.getExecutor().execute(() -> {
             if (!msg.isFromGuild()) return;
-            if (!GUILDS.contains(msg.getGuildId())) return;
+            if (!GUILDS.contains(msg.getGuildId())) {
+            	msg.reply("Your server is not on the allowlist for Gist Paste. Please contact the server admin if you use wish to use this functionality.").mentionRepliedUser(false).queue();
+            	return;
+            	}
 
             var attachments = msg.getAttachments();
             if (attachments.isEmpty()) return;

--- a/src/main/java/org/mangorage/mangobot/modules/github/PasteRequestModule.java
+++ b/src/main/java/org/mangorage/mangobot/modules/github/PasteRequestModule.java
@@ -159,12 +159,13 @@ public class PasteRequestModule {
                 var suceeeded = new AtomicBoolean(false);
                 for (Message.Attachment attachment : attachments) {
                     try {
-                        byte[] bytes = getData(attachment.getProxy().download().get());
+                    	InputStream stream = attachment.getProxy().download().get();
+                        byte[] bytes = getData(stream);
                         if (bytes == null) continue;
                         String content = new String(bytes, StandardCharsets.UTF_8);
                         if (containsPrintableCharacters(content)) {
                             suceeeded.set(true);
-                            LogAnalyser.readLog(message, content);
+                            LogAnalyser.readLog(message, stream);
                             break;
                         }
                     } catch (InterruptedException | ExecutionException e) {

--- a/src/main/java/org/mangorage/mangobot/modules/logs/BrokenDrivers.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/BrokenDrivers.java
@@ -1,0 +1,48 @@
+/*
+ * This file is written by Asbestosstar. It is not copyrighted, and a Ruby version will be included in the FeatureCreep Moderation Bot which is also not copyrighted. 
+ * Feel free to use this in your own software. Free as in Speech, Free as in Beer, No warranties, No Export restrictions.
+ * */
+package org.mangorage.mangobot.modules.logs;
+
+import net.dv8tion.jda.api.entities.Message;
+
+public class BrokenDrivers {
+
+	public static void analyse(String str, Message messaje) {
+
+		if (str.contains("EXCEPTION_ACCESS_VIOLATION") && str.contains("atio6axx.dll")) {
+			messaje.reply(
+					"You have broken AMD or ATI Graphics Drivers, updating from Device Manager wont fix it. Read this guide to fix them: https://forums.minecraftforge.net/topic/125488-rules-and-frequently-asked-questions-faq/#:~:text=How%20do%20I%20update%20my%20drivers%3F")
+					.setSuppressEmbeds(true).mentionRepliedUser(true).queue();
+		} else if (str.contains("EXCEPTION_ACCESS_VIOLATION") && str.contains("nouveau")) { // FUCKK I forgot the name
+																							// of the full file that
+																							// sometimes causes crashes,
+																							// was it like nouveau.so ?
+			messaje.reply(
+					"Some older versions sometimes have a few issues with some Nouveau Graphics on early loading screen")
+					.setSuppressEmbeds(true).mentionRepliedUser(true).queue();
+		} else {
+			String last = null;
+
+			String nl = System.getProperty("line.separator");
+
+			for (String line : str.split(nl)) {
+				last = line;
+			}
+
+			if (last != null) {
+
+				if (last.contains("Backend library: LWJGL") || last.contains("Trying GL version")
+						|| last.contains("you probably have a driver issue")) {
+					messaje.reply(
+							"You have an issue with your Graphics Drivers. If you have an AMD/ATI GPU or APU update your AMD graphics drivers. If you have an NVIDIA graphics card make sure to mark the game and all instances of javaw.exe to use the dedicated graphics card. Read this guide: https://forums.minecraftforge.net/topic/125488-rules-and-frequently-asked-questions-faq/#:~:text=How%20do%20I%20update%20my%20drivers%3F")
+							.setSuppressEmbeds(true).mentionRepliedUser(true).queue();
+				}
+
+			}
+
+		}
+
+	}
+
+}

--- a/src/main/java/org/mangorage/mangobot/modules/logs/BrokenDrivers.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/BrokenDrivers.java
@@ -6,13 +6,13 @@ package org.mangorage.mangobot.modules.logs;
 
 import net.dv8tion.jda.api.entities.Message;
 
-public class BrokenDrivers {
+public class BrokenDrivers implements LogAnalyserModule{
 
-	public static void analyse(String str, Message messaje) {
+	public void analyse(String str, Message messaje) {
 
 		if (str.contains("EXCEPTION_ACCESS_VIOLATION") && str.contains("atio6axx.dll")) {
 			messaje.reply(
-					"You have broken AMD or ATI Graphics Drivers, updating from Device Manager wont fix it. Read this guide to fix them: https://forums.minecraftforge.net/topic/125488-rules-and-frequently-asked-questions-faq/#:~:text=How%20do%20I%20update%20my%20drivers%3F")
+					"You have broken AMD or ATI Graphics Drivers, updating from Device Manager wont fix this issue. Read this guide to fix them: https://forums.minecraftforge.net/topic/125488-rules-and-frequently-asked-questions-faq/#:~:text=How%20do%20I%20update%20my%20drivers%3F")
 					.setSuppressEmbeds(true).mentionRepliedUser(true).queue();
 		} else if (str.contains("EXCEPTION_ACCESS_VIOLATION") && str.contains("nouveau")) { // FUCKK I forgot the name
 																							// of the full file that

--- a/src/main/java/org/mangorage/mangobot/modules/logs/EarlyWindow.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/EarlyWindow.java
@@ -1,0 +1,39 @@
+/*
+ * This file is written by Asbestosstar. It is not copyrighted, and a Ruby version will be included in the FeatureCreep Moderation Bot which is also not copyrighted. 
+ * Feel free to use this in your own software. Free as in Speech, Free as in Beer, No warranties, No Export restrictions.
+ * */
+package org.mangorage.mangobot.modules.logs;
+
+import net.dv8tion.jda.api.entities.Message;
+
+public class EarlyWindow {
+
+	public static void analyse(String str, Message messaje) {
+
+
+			String last = null;
+
+			String nl = System.getProperty("line.separator");
+
+			for (String line : str.split(nl)) {
+				last = line;
+			}
+
+			if (last != null) {
+
+				if (last.contains("Loading ImmediateWindowProvider fmlearlywindow")) {
+					messaje.reply("Your FML Early Window is failing. "
+							+ "To Change this go to (.)minecraft/config/fml.toml"
+							+ "Edit earlyWindowProvider to be earlyWindowProvider=\"none\""
+							+ "If you are on an M1 Mac you should also make sure you are using an ARM version of Java not an Intel x64 one."
+							+ "This is also a common issue if you have outdated Drivers. Please check this guide if on windows and turning of this does not work. https://forums.minecraftforge.net/topic/125488-rules-and-frequently-asked-questions-faq/#:~:text=How%20do%20I%20update%20my%20drivers%3F")
+							.setSuppressEmbeds(true).mentionRepliedUser(true).queue();
+				}
+
+			}
+
+		
+
+	}
+
+}

--- a/src/main/java/org/mangorage/mangobot/modules/logs/EarlyWindow.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/EarlyWindow.java
@@ -6,9 +6,9 @@ package org.mangorage.mangobot.modules.logs;
 
 import net.dv8tion.jda.api.entities.Message;
 
-public class EarlyWindow {
+public class EarlyWindow  implements LogAnalyserModule{
 
-	public static void analyse(String str, Message messaje) {
+	public void analyse(String str, Message messaje) {
 
 
 			String last = null;

--- a/src/main/java/org/mangorage/mangobot/modules/logs/Java22.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/Java22.java
@@ -6,9 +6,9 @@ package org.mangorage.mangobot.modules.logs;
 
 import net.dv8tion.jda.api.entities.Message;
 
-public class Java22 {
+public class Java22  implements LogAnalyserModule{
 
-	public static void analyse(String str, Message messaje) {
+	public void analyse(String str, Message messaje) {
 
 		String out ="Please use Java 17 for 1.17-1.20.4 and Java 21 for Anything newer, Java 8 for anything older. [Guide](https://mikumikudance.jp/index.php?title=Installing_Java_For_Minecraft). If you still have issues it could be because some mod has too new or old of files.";
 		if (str.contains("java.lang.IllegalArgumentException: Unsupported class file major version")) {

--- a/src/main/java/org/mangorage/mangobot/modules/logs/Java22.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/Java22.java
@@ -15,9 +15,11 @@ public class Java22  implements LogAnalyserModule{
 			if (str.contains("--fml.forgeVersion, 4") || str.contains("--fml.forgeVersion, 3")) {
 				if (str.contains("java version 2") && !str.contains("java version 20") && !str.contains("java version 21")) {
 				out = "Java 22 and above do not work on Minecraft Versions bellow 1.20.5 for most modloaders due to ASM being outdated." + out ;
+				messaje.reply(out).setSuppressEmbeds(true).mentionRepliedUser(true).queue();
 				}
 			}
-			messaje.reply(out).setSuppressEmbeds(true).mentionRepliedUser(true).queue();
+		}else if(str.contains("has been compiled by a more recent version of the Java Runtime")){
+			messaje.reply("You are using an outdated version of Java "+out).setSuppressEmbeds(true).mentionRepliedUser(true).queue();
 		}
 	}
 

--- a/src/main/java/org/mangorage/mangobot/modules/logs/Java22.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/Java22.java
@@ -1,0 +1,24 @@
+/*
+ * This file is written by Asbestosstar. It is not copyrighted, and a Ruby version will be included in the FeatureCreep Moderation Bot which is also not copyrighted. 
+ * Feel free to use this in your own software. Free as in Speech, Free as in Beer, No warranties, No Export restrictions.
+ * */
+package org.mangorage.mangobot.modules.logs;
+
+import net.dv8tion.jda.api.entities.Message;
+
+public class Java22 {
+
+	public static void analyse(String str, Message messaje) {
+
+		String out ="Please use Java 17 for 1.17-1.20.4 and Java 21 for Anything newer, Java 8 for anything older. [Guide](https://mikumikudance.jp/index.php?title=Installing_Java_For_Minecraft). If you still have issues it could be because some mod has too new or old of files.";
+		if (str.contains("java.lang.IllegalArgumentException: Unsupported class file major version")) {
+			if (str.contains("--fml.forgeVersion, 4") || str.contains("--fml.forgeVersion, 3")) {
+				if (str.contains("java version 2") && !str.contains("java version 20") && !str.contains("java version 21")) {
+				out = "Java 22 and above do not work on Minecraft Versions bellow 1.20.5 for most modloaders due to ASM being outdated." + out ;
+				}
+			}
+			messaje.reply(out).setSuppressEmbeds(true).mentionRepliedUser(true).queue();
+		}
+	}
+
+}

--- a/src/main/java/org/mangorage/mangobot/modules/logs/LogAnalyser.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/LogAnalyser.java
@@ -1,0 +1,85 @@
+/*
+ * This file is written by Asbestosstar. It is not copyrighted, and a Ruby version will be included in the FeatureCreep Moderation Bot which is also not copyrighted. 
+ * Feel free to use this in your own software. Free as in Speech, Free as in Beer, No warranties, No Export restrictions.
+ * */
+
+package org.mangorage.mangobot.modules.logs;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+
+import org.mangorage.mangobot.core.Util;
+
+import net.dv8tion.jda.api.entities.Message;
+
+public class LogAnalyser {
+
+	public static String[] supported_paste_sites = new String[] { "paste.mikumikudance.jp/", "paste.centos.org/",
+			"pastebin.com/", "mclo.gs/" }; // Be sure to include slashes, Paste.ee and other sites without seperate or
+											// only raw URLs will not work, ones with fancy raw URLs like OpenSUSE paste
+											// will also not be included at this time.
+
+	public static void scanMessage(Message message) {
+		String content = message.getContentStripped();
+		for (String uri : getLogURLs(content)) {
+			InputStream log = Util.getFileInputStream(uri);
+			if (log != null) {
+				try {
+					String str = Util.getStringFromInputStream(log);
+					readLog(message, str);
+				} catch (IOException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+			}
+
+		}
+	}
+
+	public static ArrayList<String> getLogURLs(String messaje) {
+		ArrayList<String> list = new ArrayList<String>();
+		for (String word : messaje.split(" ")) {
+
+			for (String paste : supported_paste_sites) {
+				if (word.contains(paste)) {
+
+					if (paste.equals("mclo.gs/")) {
+						String[] url_arr = word.split("/");
+						String slug = url_arr[url_arr.length - 1];
+						list.add("https://api.mclo.gs/1/raw/" + slug);
+					} else if (paste.equals("pastebin.com/")) {
+						String[] url_arr = word.split("/");
+						String slug = url_arr[url_arr.length - 1];
+						list.add("https://pastebin.com/raw/" + slug);
+					} else { // Add more else ifs for other sites
+						if (word.contains("/view/raw/")) {
+							list.add(word);
+						} else if (word.contains("/view/")) {
+							list.add(word.replace("/view/", "/view/raw/"));
+						}
+
+					}
+
+				}
+
+			}
+
+		}
+
+		return list;
+	}
+
+	public static void readLog(Message messaje, String log) {
+			MissingDeps.analyse(log, messaje);
+			BrokenDrivers.analyse(log, messaje);
+			Java22.analyse(log, messaje);
+			MissingScheme.analyse(log, messaje);
+			PerfOSCounters.analyse(log, messaje);
+			SSLError.analyse(log, messaje);
+			URLClassLoaderIssue.analyse(log, messaje);
+			WeRequireAtLeastJava17.analyse(log, messaje);
+			EarlyWindow.analyse(log, messaje);
+	}
+
+}

--- a/src/main/java/org/mangorage/mangobot/modules/logs/LogAnalyser.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/LogAnalyser.java
@@ -14,13 +14,19 @@ import org.mangorage.mangobot.core.Util;
 import net.dv8tion.jda.api.entities.Message;
 
 public class LogAnalyser {
+	
+	public LogAnalyserModule[] mods;
+	
+	public LogAnalyser(LogAnalyserModule[] mods) {
+		this.mods=mods;
+	}
 
-	public static String[] supported_paste_sites = new String[] { "paste.mikumikudance.jp/", "paste.centos.org/",
+	public String[] supported_paste_sites = new String[] { "paste.mikumikudance.jp/", "paste.centos.org/",
 			"pastebin.com/", "mclo.gs/" }; // Be sure to include slashes, Paste.ee and other sites without seperate or
 											// only raw URLs will not work, ones with fancy raw URLs like OpenSUSE paste
 											// will also not be included at this time.
 
-	public static void scanMessage(Message message) {
+	public void scanMessage(Message message) {
 		String content = message.getContentStripped();
 		for (String uri : getLogURLs(content)) {
 			InputStream log = Util.getFileInputStream(uri);
@@ -34,10 +40,10 @@ public class LogAnalyser {
 				}
 			}
 
-		}
+		}			
 	}
 
-	public static ArrayList<String> getLogURLs(String messaje) {
+	public ArrayList<String> getLogURLs(String messaje) {
 		ArrayList<String> list = new ArrayList<String>();
 		for (String word : messaje.split(" ")) {
 
@@ -70,16 +76,10 @@ public class LogAnalyser {
 		return list;
 	}
 
-	public static void readLog(Message messaje, String log) {
-			MissingDeps.analyse(log, messaje);
-			BrokenDrivers.analyse(log, messaje);
-			Java22.analyse(log, messaje);
-			MissingScheme.analyse(log, messaje);
-			PerfOSCounters.analyse(log, messaje);
-			SSLError.analyse(log, messaje);
-			URLClassLoaderIssue.analyse(log, messaje);
-			WeRequireAtLeastJava17.analyse(log, messaje);
-			EarlyWindow.analyse(log, messaje);
+	public void readLog(Message messaje, String log) {
+		for(LogAnalyserModule mod:mods) {
+		mod.analyse(log, messaje);
+		}
 	}
 
 }

--- a/src/main/java/org/mangorage/mangobot/modules/logs/LogAnalyserModule.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/LogAnalyserModule.java
@@ -1,0 +1,9 @@
+package org.mangorage.mangobot.modules.logs;
+
+import net.dv8tion.jda.api.entities.Message;
+
+public interface LogAnalyserModule {
+
+	public void analyse(String str, Message messaje);
+	
+}

--- a/src/main/java/org/mangorage/mangobot/modules/logs/MissingDeps.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/MissingDeps.java
@@ -1,0 +1,33 @@
+/*
+ * This file is written by Asbestosstar. It is not copyrighted, and a Ruby version will be included in the FeatureCreep Moderation Bot which is also not copyrighted. 
+ * Feel free to use this in your own software. Free as in Speech, Free as in Beer, No warranties, No Export restrictions.
+ * */
+package org.mangorage.mangobot.modules.logs;
+
+import net.dv8tion.jda.api.entities.Message;
+
+public class MissingDeps {
+
+	public static void analyse(String str, Message messaje) {
+
+		if (str.contains("Missing or unsupported mandatory dependencies:")) {
+			String nl = System.getProperty("line.separator");
+			
+			String out = "Missing or unsupported mandatory dependencies:" + nl;
+
+			for(String line: str.split(nl)) {
+					if (line.contains("Mod ID") && line.contains("Requested by") && line.contains("Expected range")) {
+						out = out + line + nl;
+					}
+			}
+			messaje.reply(out).setSuppressEmbeds(true).mentionRepliedUser(true).queue();
+		}
+	
+
+			
+
+		}
+
+	
+
+}

--- a/src/main/java/org/mangorage/mangobot/modules/logs/MissingDeps.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/MissingDeps.java
@@ -6,9 +6,9 @@ package org.mangorage.mangobot.modules.logs;
 
 import net.dv8tion.jda.api.entities.Message;
 
-public class MissingDeps {
+public class MissingDeps  implements LogAnalyserModule{
 
-	public static void analyse(String str, Message messaje) {
+	public void analyse(String str, Message messaje) {
 
 		if (str.contains("Missing or unsupported mandatory dependencies:")) {
 			String nl = System.getProperty("line.separator");

--- a/src/main/java/org/mangorage/mangobot/modules/logs/MissingScheme.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/MissingScheme.java
@@ -1,0 +1,20 @@
+/*
+ * This file is written by Asbestosstar. It is not copyrighted, and a Ruby version will be included in the FeatureCreep Moderation Bot which is also not copyrighted. 
+ * Feel free to use this in your own software. Free as in Speech, Free as in Beer, No warranties, No Export restrictions.
+ * */
+package org.mangorage.mangobot.modules.logs;
+
+import net.dv8tion.jda.api.entities.Message;
+
+public class MissingScheme {
+
+	public static void analyse(String str, Message messaje) {
+
+		if (str.contains("Caused by: java.lang.IllegalArgumentException: Missing scheme")
+				&& str.contains("org.jboss.modules")) {
+			messaje.reply("Update FeatureCreep").setSuppressEmbeds(true).mentionRepliedUser(true).queue();
+		}
+
+	}
+
+}

--- a/src/main/java/org/mangorage/mangobot/modules/logs/MissingScheme.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/MissingScheme.java
@@ -6,9 +6,9 @@ package org.mangorage.mangobot.modules.logs;
 
 import net.dv8tion.jda.api.entities.Message;
 
-public class MissingScheme {
+public class MissingScheme  implements LogAnalyserModule{
 
-	public static void analyse(String str, Message messaje) {
+	public void analyse(String str, Message messaje) {
 
 		if (str.contains("Caused by: java.lang.IllegalArgumentException: Missing scheme")
 				&& str.contains("org.jboss.modules")) {

--- a/src/main/java/org/mangorage/mangobot/modules/logs/PerfOSCounters.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/PerfOSCounters.java
@@ -6,12 +6,12 @@ package org.mangorage.mangobot.modules.logs;
 
 import net.dv8tion.jda.api.entities.Message;
 
-public class PerfOSCounters {
+public class PerfOSCounters  implements LogAnalyserModule{
 
-	public static void analyse(String str, Message messaje) {
+	public void analyse(String str, Message messaje) {
 
 		if (str.contains("Invalid registry value type detected for PerfOS counters")&&str.contains("com.modrinth.theseus")) {
-				messaje.reply("This is a comon issue on Theseus. Do not use Modrinth or their launcher, it is not good, especially on Forge. If you need to download a Modrinth format modpack you can use Prism Launcher, GDLauncher, ATLauncher, SKLauncher, or others which are far more reliable.").setSuppressEmbeds(true).mentionRepliedUser(true).queue();
+				messaje.reply("This is a common issue on Modrinth Theseus. Do not use Modrinth or their launcher, it is not good, especially on Forge. If you need to download a Modrinth format modpack you can use Prism Launcher, GDLauncher, ATLauncher, SKLauncher, or others which are far more reliable.").setSuppressEmbeds(true).mentionRepliedUser(true).queue();
 		}
 	}
 

--- a/src/main/java/org/mangorage/mangobot/modules/logs/PerfOSCounters.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/PerfOSCounters.java
@@ -1,0 +1,18 @@
+/*
+ * This file is written by Asbestosstar. It is not copyrighted, and a Ruby version will be included in the FeatureCreep Moderation Bot which is also not copyrighted. 
+ * Feel free to use this in your own software. Free as in Speech, Free as in Beer, No warranties, No Export restrictions.
+ * */
+package org.mangorage.mangobot.modules.logs;
+
+import net.dv8tion.jda.api.entities.Message;
+
+public class PerfOSCounters {
+
+	public static void analyse(String str, Message messaje) {
+
+		if (str.contains("Invalid registry value type detected for PerfOS counters")&&str.contains("com.modrinth.theseus")) {
+				messaje.reply("This is a comon issue on Theseus. Do not use Modrinth or their launcher, it is not good, especially on Forge. If you need to download a Modrinth format modpack you can use Prism Launcher, GDLauncher, ATLauncher, SKLauncher, or others which are far more reliable.").setSuppressEmbeds(true).mentionRepliedUser(true).queue();
+		}
+	}
+
+}

--- a/src/main/java/org/mangorage/mangobot/modules/logs/SSLError.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/SSLError.java
@@ -1,0 +1,18 @@
+/*
+ * This file is written by Asbestosstar. It is not copyrighted, and a Ruby version will be included in the FeatureCreep Moderation Bot which is also not copyrighted. 
+ * Feel free to use this in your own software. Free as in Speech, Free as in Beer, No warranties, No Export restrictions.
+ * */
+package org.mangorage.mangobot.modules.logs;
+
+import net.dv8tion.jda.api.entities.Message;
+
+public class SSLError {
+
+	public static void analyse(String str, Message messaje) {
+
+		if (str.contains("net.minecraftforge.installertools")&&str.contains("sun.security.validator.PKIXValidator")) {
+				messaje.reply("This issue is in most cases caused by an outdated version of Java with issues with Let's Encrypt SSL. Please Update to a newer build of Java [Guide](https://mikumikudance.jp/index.php?title=Installing_Java_For_Minecraft). It can also be caused by networking issues.").setSuppressEmbeds(true).mentionRepliedUser(true).queue();
+		}
+	}
+
+}

--- a/src/main/java/org/mangorage/mangobot/modules/logs/SSLError.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/SSLError.java
@@ -6,9 +6,9 @@ package org.mangorage.mangobot.modules.logs;
 
 import net.dv8tion.jda.api.entities.Message;
 
-public class SSLError {
+public class SSLError  implements LogAnalyserModule{
 
-	public static void analyse(String str, Message messaje) {
+	public void analyse(String str, Message messaje) {
 
 		if (str.contains("net.minecraftforge.installertools")&&str.contains("sun.security.validator.PKIXValidator")) {
 				messaje.reply("This issue is in most cases caused by an outdated version of Java with issues with Let's Encrypt SSL. Please Update to a newer build of Java [Guide](https://mikumikudance.jp/index.php?title=Installing_Java_For_Minecraft). It can also be caused by networking issues.").setSuppressEmbeds(true).mentionRepliedUser(true).queue();

--- a/src/main/java/org/mangorage/mangobot/modules/logs/URLClassLoaderIssue.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/URLClassLoaderIssue.java
@@ -6,17 +6,10 @@ package org.mangorage.mangobot.modules.logs;
 
 import net.dv8tion.jda.api.entities.Message;
 
-public class URLClassLoaderIssue {
+public class URLClassLoaderIssue  implements LogAnalyserModule{
 
 	
-	
-	/*
-	 * This file is written by Asbestosstar. It is not copyrighted, and a Ruby version will be included in the FeatureCreep Moderation Bot which is also not copyrighted. 
-	 * Feel free to use this in your own software. Free as in Speech, Free as in Beer, No warranties, No Export restrictions.
-	 * */
-
-	
-	public static void analyse(String str, Message messaje) {
+	public void analyse(String str, Message messaje) {
 
 		if (str.contains("jdk.internal.loader.ClassLoaders$AppClassLoader cannot be cast to class java.net.URLClassLoader")) {
 			messaje.reply("Use Java 8. [Guide](https://mikumikudance.jp/index.php?title=Installing_Java_For_Minecraft).").setSuppressEmbeds(true).mentionRepliedUser(true).queue();

--- a/src/main/java/org/mangorage/mangobot/modules/logs/URLClassLoaderIssue.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/URLClassLoaderIssue.java
@@ -1,0 +1,31 @@
+/*
+ * This file is written by Asbestosstar. It is not copyrighted, and a Ruby version will be included in the FeatureCreep Moderation Bot which is also not copyrighted. 
+ * Feel free to use this in your own software. Free as in Speech, Free as in Beer, No warranties, No Export restrictions.
+ * */
+package org.mangorage.mangobot.modules.logs;
+
+import net.dv8tion.jda.api.entities.Message;
+
+public class URLClassLoaderIssue {
+
+	
+	
+	/*
+	 * This file is written by Asbestosstar. It is not copyrighted, and a Ruby version will be included in the FeatureCreep Moderation Bot which is also not copyrighted. 
+	 * Feel free to use this in your own software. Free as in Speech, Free as in Beer, No warranties, No Export restrictions.
+	 * */
+
+	
+	public static void analyse(String str, Message messaje) {
+
+		if (str.contains("jdk.internal.loader.ClassLoaders$AppClassLoader cannot be cast to class java.net.URLClassLoader")) {
+			messaje.reply("Use Java 8. [Guide](https://mikumikudance.jp/index.php?title=Installing_Java_For_Minecraft).").setSuppressEmbeds(true).mentionRepliedUser(true).queue();
+		}
+
+	}
+	
+	
+	
+	
+	
+}

--- a/src/main/java/org/mangorage/mangobot/modules/logs/WeRequireAtLeastJava17.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/WeRequireAtLeastJava17.java
@@ -1,0 +1,30 @@
+/*
+ * This file is written by Asbestosstar. It is not copyrighted, and a Ruby version will be included in the FeatureCreep Moderation Bot which is also not copyrighted. 
+ * Feel free to use this in your own software. Free as in Speech, Free as in Beer, No warranties, No Export restrictions.
+ * */
+package org.mangorage.mangobot.modules.logs;
+
+import net.dv8tion.jda.api.entities.Message;
+
+public class WeRequireAtLeastJava17 {
+
+	
+	
+
+
+	
+	public static void analyse(String str, Message messaje) {
+
+		if (str.contains("Current Java is") && str.contains("but we require at least")) {
+			messaje.reply("You are using old Java version. Use Java 17 for 1.17-1.20.4 or Java 21 for 1.20.5+. [Guide](https://mikumikudance.jp/index.php?title=Installing_Java_For_Minecraft).").setSuppressEmbeds(true).mentionRepliedUser(true).queue();
+		}else if (str.contains("Error: could not open") && str.contains("user_jvm_args.txt")) {
+			messaje.reply("You are using old Java version. Use Java 17 for 1.17-1.20.4 or Java 21 for 1.20.5+. [Guide](https://mikumikudance.jp/index.php?title=Installing_Java_For_Minecraft).").setSuppressEmbeds(true).mentionRepliedUser(true).queue();
+		}
+
+	}
+	
+	
+	
+	
+	
+}

--- a/src/main/java/org/mangorage/mangobot/modules/logs/WeRequireAtLeastJava17.java
+++ b/src/main/java/org/mangorage/mangobot/modules/logs/WeRequireAtLeastJava17.java
@@ -6,14 +6,14 @@ package org.mangorage.mangobot.modules.logs;
 
 import net.dv8tion.jda.api.entities.Message;
 
-public class WeRequireAtLeastJava17 {
+public class WeRequireAtLeastJava17  implements LogAnalyserModule{
 
 	
 	
 
 
 	
-	public static void analyse(String str, Message messaje) {
+	public void analyse(String str, Message messaje) {
 
 		if (str.contains("Current Java is") && str.contains("but we require at least")) {
 			messaje.reply("You are using old Java version. Use Java 17 for 1.17-1.20.4 or Java 21 for 1.20.5+. [Guide](https://mikumikudance.jp/index.php?title=Installing_Java_For_Minecraft).").setSuppressEmbeds(true).mentionRepliedUser(true).queue();


### PR DESCRIPTION
I have added Log analyser with a bunch of common issues. 
Broken Drivers
Early Window Change
Java 22 on versions before 1.20.5
Missing Dependencies (This one is the most important as I always miss it when manually viewing logs)
Missing Scheme (FeatureCreep specific)
PerfOS error on Modrinth Thesues
SSL Errors on the Installer
URL ClassLoader error when running on too new Java version
We Require Java 17/21 Error

This reads the logs and if it detects one of these errors it explains what to do or links to a guide on how to fix the issue. It is very easy to modify the existing detections to stop false positive or add better detection and its also very easy to turn these on or off (just go to the readLogs method on the bottom of LogAnalyser and add or comment out a module.) It works on both single file upload (does not currently support more than 1 file at a time), and a few paste sites from our log trick or some other common ones like Pastebin.com and mclo.gs. This will make filtering out the common errors much faster and easier.